### PR TITLE
Add ability to use custom headers when serving tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var disk = require('tilestrata-disk');
 // cache: cache tiles to disk
 server.layer('mylayer').route('tile.png')
     .use(/* some provider */)
-    .use(disk.cache({dir: './tiles/mylayer'}));
+    .use(disk.cache({dir: './tiles/mylayer', headers: { 'Content-Encoding': 'gzip' }}));
 
 // cache: cache with maxage
 server.layer('mylayer').route('tile.png')
@@ -52,6 +52,10 @@ server.layer('mylayer').route('tile.png')
 // provider: serve pre-existing / pre-sliced tiles off disk
 server.layer('mylayer').route('tile.png')
     .use(disk.provider('/path/to/dir/{z}/{x}/{y}/file.png'));
+
+// provider: serve pre-existing tiles with custom headers
+server.layer('mylayer').route('tile.png')
+    .use(disk.provider('/path/to/dir/{z}/{x}/{y}/file.png', {headers: {'Content-Encoding': 'gzip'}}));
 ```
 
 Some sample values of `maxage` are:

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -98,7 +98,8 @@ FileSystemCache.prototype.get = function(server, req, callback) {
 			if (!shouldServe) return done();
 			var shouldRefresh = self.shouldRefresh(mtime, req);
 
-			var headers = {'Content-Type': mime(file)};
+			var headers = (self.options && self.options.headers) || {};
+			headers['Content-Type'] = mime(file);
 
 			var buffer = new Buffer(stats.size);
 			if (!stats.size) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,7 +1,7 @@
 var fs = require('fs-extra');
 var mime = require('./mime.js');
 
-module.exports = function(template) {
+module.exports = function(template, options) {
 	return {
 		name: 'disk',
 		serve: function(server, tile, callback) {
@@ -21,7 +21,11 @@ module.exports = function(template) {
 					}
 					return callback(err);
 				}
-				callback(null, buffer, {'Content-Type': mime(file)});
+
+				var headers = (options && options.headers) || {};
+				headers['Content-Type'] = mime(file);
+
+				callback(null, buffer, headers);
 			});
 		}
 	};

--- a/test/cache.js
+++ b/test/cache.js
@@ -238,6 +238,25 @@ describe('Cache Implementation "disk"', function() {
 				});
 			});
 		});
+		it('should retrieve file with custom headers', function(done) {
+			var server = new TileServer();
+			var req = TileRequest.parse('/layer/3/2/1/tile.txt');
+			var dir = __dirname + '/fixtures/sample';
+			var cache = disk.cache({dir: dir, headers: { 'Content-Encoding': 'gzip' }});
+			cache.init(server, function(err) {
+				if (err) throw err;
+				cache.get(server, req, function(err, buffer, headers) {
+					if (err) throw err;
+					assert.instanceOf(buffer, Buffer);
+					assert.equal(buffer.toString('utf8'), 'Hello World');
+					assert.deepEqual(headers, {
+						'Content-Type': 'text/plain; charset=UTF-8',
+					 	'Content-Encoding': 'gzip'
+					});
+					done();
+				});
+			});
+		});
 	});
 	it('should allow "path" template string', function(done) {
 		var server = new TileServer();

--- a/test/provider.js
+++ b/test/provider.js
@@ -22,6 +22,17 @@ describe('Provider Implementation "disk"', function() {
 				done();
 			});
 		});
+		it('should serve file with custom headers', function(done) {
+			var server = new TileServer();
+			var provider = disk.provider(__dirname + '/fixtures/sample/{z}/{x}/{y}/tile.txt', {headers: {'Content-Encoding': 'gzip'}});
+			var req = TileRequest.parse('/basemap/3/2/1/tile.txt', {'x-tilestrata-skipcache':'1','x-random':'1'}, 'HEAD');
+			provider.serve(server, req, function(err, buffer, headers) {
+				if (err) throw err;
+				assert.equal(buffer.toString('utf8'), 'Hello World');
+				assert.deepEqual(headers, {'Content-Type': 'text/plain; charset=UTF-8', 'Content-Encoding': 'gzip'});
+				done();
+			});
+		});
 		it('should return 404 if it doesn\'t exist', function(done) {
 			var server = new TileServer();
 			var provider = disk.provider(__dirname + '/sample-doesnotexist/{z}/{x}/{y}/tile.txt');


### PR DESCRIPTION
Fixes #2: if cached tiles are compressed with gzip we need to specify additional headers in order to process the tiles correctly. In other cases we will get  `Uncaught Error: Unimplemented type: 3` exception for Mapbox service.

The syntax is short and clear:

### cache

```javascript
use(disk.cache({dir: './tiles/mylayer', headers: { 'Content-Encoding': 'gzip' }}));
```

### provider

```javascript
.use(disk.provider('/path/to/dir/{z}/{x}/{y}/file.png', {headers: {'Content-Encoding': 'gzip'}}));
```

_NB_: I think that in the future there are can be more options, so I decided to extract it to `headers`.