### PR TITLE
Store and replay headers

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -91,31 +91,31 @@ FileSystemCache.prototype.get = function(server, req, callback) {
 			return callback(err);
 		}
 
-	fs.open(file, 'r', function(err, fd) {
-		if (err) {
-			if (err.code === 'ENOENT') return callback();
-			return callback(err);
-		}
-		_fd = fd;
-		fs.fstat(fd, function(err, stats) {
-			if (err) return done(err);
-
-			var mtime = stats.mtime.getTime();
-			var shouldServe = self.shouldServe(mtime, req);
-			if (!shouldServe) return done();
-			var shouldRefresh = self.shouldRefresh(mtime, req);
-
-			var buffer = new Buffer(stats.size);
-			if (!stats.size) {
-				return done(null, buffer, headers, shouldRefresh);
+		fs.open(file, 'r', function(err, fd) {
+			if (err) {
+				if (err.code === 'ENOENT') return callback();
+				return callback(err);
 			}
-
-			fs.read(fd, buffer, 0, stats.size, 0, function(err) {
+			_fd = fd;
+			fs.fstat(fd, function(err, stats) {
 				if (err) return done(err);
-				done(null, buffer, headers, shouldRefresh);
+
+				var mtime = stats.mtime.getTime();
+				var shouldServe = self.shouldServe(mtime, req);
+				if (!shouldServe) return done();
+				var shouldRefresh = self.shouldRefresh(mtime, req);
+
+				var buffer = new Buffer(stats.size);
+				if (!stats.size) {
+					return done(null, buffer, headers, shouldRefresh);
+				}
+
+				fs.read(fd, buffer, 0, stats.size, 0, function(err) {
+					if (err) return done(err);
+					done(null, buffer, headers, shouldRefresh);
+				});
 			});
 		});
-	});
 	});
 };
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,5 +1,4 @@
 var fs = require('fs-extra');
-var mime = require('./mime.js');
 
 function FileSystemCache(options) {
 	this.options = options || {};

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -84,6 +84,13 @@ FileSystemCache.prototype.get = function(server, req, callback) {
 
 	var self = this;
 	var file = this._file(req);
+
+	fs.readJson(file + '.headers', function (err, headers) {
+		if (err) {
+			if (err.code === 'ENOENT') return callback();
+			return callback(err);
+		}
+
 	fs.open(file, 'r', function(err, fd) {
 		if (err) {
 			if (err.code === 'ENOENT') return callback();
@@ -98,8 +105,6 @@ FileSystemCache.prototype.get = function(server, req, callback) {
 			if (!shouldServe) return done();
 			var shouldRefresh = self.shouldRefresh(mtime, req);
 
-			var headers = {'Content-Type': mime(file)};
-
 			var buffer = new Buffer(stats.size);
 			if (!stats.size) {
 				return done(null, buffer, headers, shouldRefresh);
@@ -110,6 +115,7 @@ FileSystemCache.prototype.get = function(server, req, callback) {
 				done(null, buffer, headers, shouldRefresh);
 			});
 		});
+	});
 	});
 };
 
@@ -124,8 +130,12 @@ FileSystemCache.prototype.get = function(server, req, callback) {
  */
 FileSystemCache.prototype.set = function(server, req, buffer, headers, callback) {
 	var maxage = this.ageTolerance('maxage', req);
+	var file = this._file(req);
 	if (maxage === 0) return callback();
-	fs.outputFile(this._file(req), buffer, callback);
+	fs.outputFile(file, buffer, function (err) {
+		if (err) return callback(err);
+		fs.outputJson(file + '.headers', headers, callback);
+	});
 };
 
 module.exports = function(options) {


### PR DESCRIPTION
Currently, headers passed to `set` are discarded. `get` then reconstructs a `Content-Type` header using `mime.js`, but other headers can't be reconstructed. This causes problems like those in #2.

This patch proposes to store the headers passed to `set` as a JSON document in an adjunct file, and then serve up those headers when `get` is called.